### PR TITLE
solve "permission denied, open logs/****"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,3 +40,5 @@ RUN jq '.redis = { port: 6379, host: "redis" }' config/default.json > config/tmp
     mv config/tmp.json config/default.json
 
 RUN npm install && npm run build
+# "npm start" with root
+USER root


### PR DESCRIPTION
#5 主机上的docker一般是root权限来操作的，如果bind的volumes不存在，会已以root权限创建。所以如果以easy-mock用户执行“npm start”命令，会有文件权限问题，如下：

![default](https://user-images.githubusercontent.com/15139854/38727316-4314e42e-3f3f-11e8-9053-e24f7774619a.png)
