### PR TITLE
docs: add a notice that resolve the file permission error

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,11 @@ networks:
   ......
 }
 ```
+* **如果遇到 easymock docker 实例报文件权限错误**
+```
+Error: EACCES: permission denied....
+```
+**可在项目根目录执行以下命令**
+```
+chmod 777 /yourfile/logs
+```


### PR DESCRIPTION
https://github.com/easy-mock/easy-mock-docker/issues/20

当未使用root权限构建docker时，easymock 实例无法拥有 logs 文件夹的写权限，导致 npm run start 失败

```
Error: EACCES: permission denied, open 'logs/2019-06-19-info.log'
```

更改指定文件夹的读写权限后，错误fix
```
chmod 777 ./logs
```

补充文档记录一下注意事项